### PR TITLE
Specify account owner for fck-nat AMI

### DIFF
--- a/cdk/vpc.ts
+++ b/cdk/vpc.ts
@@ -18,6 +18,7 @@ export const createVpc = (scope: Stack): IVpc =>
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MICRO),
       machineImage: new LookupMachineImage({
         name: 'fck-nat-*-arm64-ebs',
+        owners: ['568608671756'],
       }),
     }),
     subnetConfiguration: [


### PR DESCRIPTION
The example code in the fck-nat repo had an issue where it didn't specify the AMI owner which opens up the possibility for pulling an unofficial fck-nat AMI.